### PR TITLE
Create a Join Method on the Core Classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "core-ct"
-version = "0.4.1"
+version = "0.5.0"
 description = "A Python library to assist geologists with the analysis of rock core CT scans"
 authors = [
     "Kira Hanson <khanson@mines.edu>",

--- a/src/core_ct/core.py
+++ b/src/core_ct/core.py
@@ -290,7 +290,10 @@ class Core:
         Arguments:
         ---------
             core: the `Core` object to join with the current core
-            axis: the axis to join the cores on
+            axis: integer specifying which axis to rotate about (0, 1, or 2)
+                    0: x-axis
+                    1: y-axis
+                    2: z-axis
 
         Returns:
         -------
@@ -298,9 +301,9 @@ class Core:
 
         Raises:
         ------
-            Exception if axis is a value other than 0, 1, or 2
-            Exception if the `pixel_dimensions` of the cores don't match
-            Exception if the shapes of the cores along an axis don't match
+            ValueError if axis is a value other than 0, 1, or 2
+            ValueError if the `pixel_dimensions` of the cores don't match
+            ValueError if the shapes of the cores along an axis don't match
         """
         # Check that the axis values are valid
         if axis < 0 or axis > 2:

--- a/src/core_ct/core.py
+++ b/src/core_ct/core.py
@@ -285,7 +285,7 @@ class Core:
 
     def join(self, core: Core, axis: int = 0) -> Core:
         """
-        Output an image containing the slice at the provided index.
+        Join a core to the current core on specified axis.
 
         Arguments:
         ---------

--- a/src/core_ct/core.py
+++ b/src/core_ct/core.py
@@ -290,7 +290,7 @@ class Core:
         Arguments:
         ---------
             core: the `Core` object to join with the current core
-            axis: integer specifying which axis to rotate about (0, 1, or 2)
+            axis: integer specifying which axis to join the cores on
                     0: x-axis
                     1: y-axis
                     2: z-axis

--- a/src/core_ct/core.py
+++ b/src/core_ct/core.py
@@ -300,23 +300,15 @@ class Core:
         if axis < 0 or axis > 2:
             raise ValueError("axis must be a value between 0 and 2 (inclusive)")
 
-        # Get the pixel array and dimensions of the source and target cores
-        source_pixel_array = core.pixel_array
-        source_pixel_dimensions = core.pixel_dimensions
-        target_pixel_array = self.pixel_array
-        target_pixel_dimensions = self.pixel_dimensions
-
         # Check that the pixel dimensions match between the two cores
-        if source_pixel_dimensions != target_pixel_dimensions:
+        if core.pixel_dimensions != self.pixel_dimensions:
             raise ValueError(
-                "{source} != {target}, the core's pixel dimensions must match".format(
-                    source=source_pixel_dimensions, target=target_pixel_dimensions
+                "the core's pixel dimensions must match, {source} != {target}".format(
+                    source=core.pixel_dimensions, target=self.pixel_dimensions
                 )
             )
 
         # Join the two pixel arrays together
-        joined_pixel_array = np.append(
-            target_pixel_array, source_pixel_array, axis=axis
-        )
+        joined_pixel_array = np.append(self.pixel_array, core.pixel_array, axis=axis)
 
-        return Core(joined_pixel_array, source_pixel_dimensions)
+        return Core(joined_pixel_array, self.pixel_dimensions)

--- a/src/core_ct/core.py
+++ b/src/core_ct/core.py
@@ -285,7 +285,7 @@ class Core:
 
     def join(self, core: Core, axis: int = 0) -> Core:
         """
-        Join a core to the current core on specified axis.
+        Join a core to the current core on a specified axis.
 
         Arguments:
         ---------

--- a/src/core_ct/core.py
+++ b/src/core_ct/core.py
@@ -137,7 +137,7 @@ class Core:
             raise ValueError("axis1 must be a value between 0 and 2 (inclusive)")
         if axis2 < 0 or axis2 > 2:
             raise ValueError("axis2 must be a value between 0 and 2 (inclusive)")
-        
+
         # swap axes in pixel array
         pixel_array = np.swapaxes(self.pixel_array, axis1, axis2)
 
@@ -145,7 +145,7 @@ class Core:
         pixel_dimensions: list[float] = copy.copy(self.pixel_dimensions)
         pixel_dimensions[axis1] = self.pixel_dimensions[axis2]
         pixel_dimensions[axis2] = self.pixel_dimensions[axis1]
-        
+
         # return new Core containing transformed data
         return Core(pixel_array=pixel_array, pixel_dimensions=pixel_dimensions)
 
@@ -171,17 +171,17 @@ class Core:
         # make sure axis inputs are valid
         if axis < 0 or axis > 2:
             raise ValueError("axis must be a value between 0 and 2 (inclusive)")
-        
+
         # swap axes in pixel array
         pixel_array = np.flip(self.pixel_array, axis)
-        
+
         # return new Core containing transformed data
         return Core(pixel_array=pixel_array, pixel_dimensions=self.pixel_dimensions)
 
     def rotate(self, axis: int, k: int = 1, clockwise: bool = False) -> Core:
         """
         Create a new `Core` object with data rotated 90 degrees about `axis` `k` times.
-        
+
         Rotates counter-clockwise by default, set `clockwise` to `True` to rotate
         clockwise instead.
 
@@ -205,11 +205,11 @@ class Core:
         # make sure axis inputs are valid
         if axis < 0 or axis > 2:
             raise ValueError("axis must be a value between 0 and 2 (inclusive)")
-        
+
         # handle clockwise/counter-clockwise conversion
         if clockwise:
             k = -k
-        
+
         # figure out which axis to use in call to numpy.rot90()
         axis1: int
         axis2: int
@@ -224,14 +224,14 @@ class Core:
             case 2:
                 axis1 = 0
                 axis2 = 1
-        
+
         pixel_array = np.rot90(self.pixel_array, k=k, axes=(axis1, axis2))
 
         # correcting pixel_dimensions below the rot90 call so pixel_dimensions won't
         # be messed up if rot90 fails
-        
+
         # figure out how to modify pixel_dimensions
-        # if k is even, the array is being rotated by a factor of 180 degrees so we 
+        # if k is even, the array is being rotated by a factor of 180 degrees so we
         # don't need to worry about switching dimensions
         pixel_dimensions: list[float] = copy.copy(self.pixel_dimensions)
         if k % 2 != 0:
@@ -282,3 +282,41 @@ class Core:
 
         new_core = Core(self.pixel_array[x1:x2, y1:y2, z1:z2], self.pixel_dimensions)
         return new_core
+
+    def join(self, core: Core, axis: int = 0) -> Core:
+        """
+        Output an image containing the slice at the provided index.
+
+        Arguments:
+        ---------
+            core: the `Core` object to join with the current core
+            axis: the axis to join the cores on
+
+        Returns:
+        -------
+            New core object made up of the two joined arrays
+        """
+        # Check that the axis values are valid
+        if axis < 0 or axis > 2:
+            raise ValueError("axis must be a value between 0 and 2 (inclusive)")
+
+        # Get the pixel array and dimensions of the source and target cores
+        source_pixel_array = core.pixel_array
+        source_pixel_dimensions = core.pixel_dimensions
+        target_pixel_array = self.pixel_array
+        target_pixel_dimensions = self.pixel_dimensions
+
+        # Check that the pixel dimensions match between the two cores
+        if source_pixel_dimensions != target_pixel_dimensions:
+            raise ValueError(
+                "{source} != {target}, the core's pixel dimensions must match".format(
+                    source=source_pixel_dimensions, target=target_pixel_dimensions
+                )
+            )
+
+        # Join the two pixel arrays together
+        joined_pixel_array = np.append(
+            target_pixel_array, source_pixel_array, axis=axis
+        )
+
+        return Core(joined_pixel_array, source_pixel_dimensions)

--- a/src/core_ct/core.py
+++ b/src/core_ct/core.py
@@ -295,6 +295,12 @@ class Core:
         Returns:
         -------
             New core object made up of the two joined arrays
+
+        Raises:
+        ------
+            Exception if axis is a value other than 0, 1, or 2
+            Exception if the `pixel_dimensions` of the cores don't match
+            Exception if the shapes of the cores along an axis don't match
         """
         # Check that the axis values are valid
         if axis < 0 or axis > 2:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ from core_ct.core import Core
 import numpy as np
 import copy
 
+
 def test_core():
     """Tests that a `Core` object can be created successfully."""
     # Define the pixel array and pixel_dimensions
@@ -33,6 +34,7 @@ def test_slice():
     assert slice_1.shape == (2, 8)
     assert slice_2.shape == (2, 4)
 
+
 def test_swapaxes():
     """Tests the `slice` method on the `Core`."""
     # Define the core
@@ -45,8 +47,9 @@ def test_swapaxes():
                 pixel_array[x, y, z] = counter
                 counter += 1
 
-    core: Core = Core(pixel_array=copy.deepcopy(pixel_array), 
-                      pixel_dimensions=[2.0, 4.0, 8.0])
+    core: Core = Core(
+        pixel_array=copy.deepcopy(pixel_array), pixel_dimensions=[2.0, 4.0, 8.0]
+    )
 
     # Swap various axes
     core_xy: Core = core.swapaxes(0, 1)
@@ -107,6 +110,7 @@ def test_swapaxes():
         # Make sure pixel_dimensions weren't altered
         assert core.pixel_dimensions == [2.0, 4.0, 8.0]
 
+
 def test_flip():
     """Tests the `flip` method on the `Core`."""
     # Define the core
@@ -119,8 +123,9 @@ def test_flip():
                 pixel_array[x, y, z] = counter
                 counter += 1
 
-    core: Core = Core(pixel_array=copy.deepcopy(pixel_array), 
-                      pixel_dimensions=[2.0, 4.0, 8.0])
+    core: Core = Core(
+        pixel_array=copy.deepcopy(pixel_array), pixel_dimensions=[2.0, 4.0, 8.0]
+    )
 
     # Flip various axes
     core_x: Core = core.flip(0)
@@ -163,6 +168,7 @@ def test_flip():
         # Make sure pixel_dimensions weren't altered
         assert core.pixel_dimensions == [2.0, 4.0, 8.0]
 
+
 def test_rotate():
     """Tests the `rotate` method on the `Core`."""
     # Define the core
@@ -175,8 +181,9 @@ def test_rotate():
                 pixel_array[x, y, z] = counter
                 counter += 1
 
-    core: Core = Core(pixel_array=copy.deepcopy(pixel_array), 
-                      pixel_dimensions=[2.0, 4.0, 8.0])
+    core: Core = Core(
+        pixel_array=copy.deepcopy(pixel_array), pixel_dimensions=[2.0, 4.0, 8.0]
+    )
 
     # Rotate various axes
     core_x: Core = core.rotate(0, k=1)
@@ -260,3 +267,13 @@ def test_rotate():
         assert np.array_equal(core.pixel_array, pixel_array)
         # Make sure pixel_dimensions weren't altered
         assert core.pixel_dimensions == [2.0, 4.0, 8.0]
+
+
+def test_join():
+    """Tests the `join` method on the `Core`."""
+    # Define the source and target cores for joining
+    source = Core(np.zeros([2, 4, 8]), [5.0, 4.0, 8.0])
+    target = Core(np.zeros([2, 4, 8]), [2.0, 4.0, 8.0])
+    joined = source.join(target)
+    print(joined.pixel_array.shape)
+    assert False

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -271,9 +271,17 @@ def test_rotate():
 
 def test_join():
     """Tests the `join` method on the `Core`."""
-    # Define the source and target cores for joining
-    source = Core(np.zeros([2, 4, 8]), [5.0, 4.0, 8.0])
+    # Define the target core for joining
     target = Core(np.zeros([2, 4, 8]), [2.0, 4.0, 8.0])
-    joined = source.join(target)
-    print(joined.pixel_array.shape)
-    assert False
+    # Define the source cores for joining
+    source_valid = Core(np.zeros([2, 4, 8]), [2.0, 4.0, 8.0])
+    # source_invalid_dimensions = Core(np.zeros([2, 4, 8]), [2.0, 4.0, 8.0])
+    # source_invalid_shape = Core(np.zeros([2, 4, 8]), [2.0, 4.0, 8.0])
+
+    # Assert the valid core joins together properly on each axis
+    joined_valid_0 = target.join(source_valid, axis=0)
+    # joined_valid_1 = target.join(source_valid, axis=1)
+    # joined_valid_2 = target.join(source_valid, axis=2)
+    assert joined_valid_0.pixel_array.shape == (4, 4, 8)
+
+    # Test that the join method fails on invalid dimensions


### PR DESCRIPTION
Created a `join` method on the core class that allows for one core to be joined with another along a specified axis. In order for this operation to be performed, the `pixel_array` dimensions of the core that _aren't_ the joined axis must match with each other and each core must have the same `pixel_dimensions`.